### PR TITLE
task-6

### DIFF
--- a/deployment/Deployment/DeploymentStack.cs
+++ b/deployment/Deployment/DeploymentStack.cs
@@ -7,7 +7,7 @@ public class DeploymentStack : Stack
 {
     internal DeploymentStack(Construct scope, string id, IStackProps props = null) : base(scope, id, props)
     {
-        _ = new ProductServiceStack(this);
-        _ = new ImportServiceStack(this);
+        var productServiceStack = new ProductServiceStack(this);
+        _ = new ImportServiceStack(this, productServiceStack.CatalogItemsQueue);
     }
 }

--- a/deployment/Deployment/ImportServiceStack.cs
+++ b/deployment/Deployment/ImportServiceStack.cs
@@ -5,6 +5,7 @@ using Amazon.CDK.AWS.Lambda;
 using Amazon.CDK.AWS.Logs;
 using Amazon.CDK.AWS.S3;
 using Amazon.CDK.AWS.S3.Notifications;
+using Amazon.CDK.AWS.SQS;
 using Amazon.CDK.AwsApigatewayv2Integrations;
 using Constructs;
 using AssetCode = Amazon.CDK.AWS.Lambda.AssetCode;
@@ -14,7 +15,7 @@ namespace Deployment;
 
 public class ImportServiceStack
 {
-    internal ImportServiceStack(Construct scope)
+    internal ImportServiceStack(Construct scope, IQueue catalogItemsQueue)
     {
         var s3Bucket = new Bucket(scope, "AwsShopImportProductsBucket", new BucketProps
         {
@@ -36,6 +37,7 @@ public class ImportServiceStack
         var lambdaEnvironment = new Dictionary<string, string>
         {
             ["IMPORT_BUCKET"] = s3Bucket.BucketName,
+            ["CATALOG_ITEMS_QUEUE"] = catalogItemsQueue.QueueName,
         };
 
         var importProductsFileFunction = new Function(scope, "ImportProductsFileLambda", new FunctionProps
@@ -66,6 +68,7 @@ public class ImportServiceStack
             });
         s3Bucket.GrantPut(importProductsFileFunction);
         s3Bucket.GrantReadWrite(importFileParserFunction);
+        catalogItemsQueue.GrantSendMessages(importFileParserFunction);
 
         var httpApi = new HttpApi(scope, "ImportServiceAPIGateway", new HttpApiProps
         {

--- a/deployment/Deployment/ProductServiceStack.cs
+++ b/deployment/Deployment/ProductServiceStack.cs
@@ -3,18 +3,41 @@ using Amazon.CDK;
 using Amazon.CDK.AWS.Apigatewayv2;
 using Amazon.CDK.AWS.DynamoDB;
 using Amazon.CDK.AWS.Lambda;
+using Amazon.CDK.AWS.Lambda.EventSources;
 using Amazon.CDK.AWS.Logs;
+using Amazon.CDK.AWS.SNS;
+using Amazon.CDK.AWS.SNS.Subscriptions;
+using Amazon.CDK.AWS.SQS;
 using Amazon.CDK.AwsApigatewayv2Integrations;
 using Constructs;
 using AssetCode = Amazon.CDK.AWS.Lambda.AssetCode;
 using HttpMethod = Amazon.CDK.AWS.Apigatewayv2.HttpMethod;
+using SubscriptionFilter = Amazon.CDK.AWS.SNS.SubscriptionFilter;
 
 namespace Deployment;
 
 public class ProductServiceStack
 {
+    public IQueue CatalogItemsQueue { get; }
+    
     internal ProductServiceStack(Construct scope)
     {
+        var snsTopic = new Topic(scope, "CatalogItemCreatedTopic", new TopicProps
+        {
+            TopicName = "catalogItemCreatedTopic",
+        });
+        snsTopic.AddSubscription(new EmailSubscription("antonkofa@gmail.com"));
+        snsTopic.AddSubscription(new EmailSubscription("ragnareck@mail.ru", new EmailSubscriptionProps
+        {
+            FilterPolicyWithMessageBody = new Dictionary<string, FilterOrPolicy>()
+            {
+                ["price"] = FilterOrPolicy.Filter(SubscriptionFilter.NumericFilter(new NumericConditions
+                {
+                    GreaterThan = 100499,
+                })),
+            },
+        }));
+
         var productsTable = new Table(scope, "AwsShop.Products", new TableProps
         {
             PartitionKey = new Attribute { Name = "id", Type = AttributeType.STRING },
@@ -29,6 +52,7 @@ public class ProductServiceStack
         {
             ["TABLE_PRODUCTS"] = productsTable.TableName,
             ["TABLE_STOCKS"] = stocksTable.TableName,
+            ["CATALOG_ITEM_CREATED_TOPIC"] = snsTopic.TopicArn,
         };
         
         var getProductsFunction = new Function(scope, "GetProductsLambda", new FunctionProps
@@ -60,13 +84,38 @@ public class ProductServiceStack
             Environment = lambdaEnvironment,
             Timeout = Duration.Minutes(1),
         });
+        
+        var catalogBatchProcessorFunction = new Function(scope, "CatalogBatchProcessorLambda", new FunctionProps
+        {
+            Runtime = new Runtime("dotnet8"),
+            Handler = "ProductService::ProductService.CatalogBatchProcessor::Function",
+            Code = new AssetCode("../dist/product-service"),
+            LogRetention = RetentionDays.ONE_DAY,
+            Environment = lambdaEnvironment,
+            Timeout = Duration.Minutes(1),
+        });
 
         productsTable.GrantFullAccess(getProductsFunction);
         productsTable.GrantFullAccess(getProductByIdFunction);
         productsTable.GrantFullAccess(addProductFunction);
+        productsTable.GrantFullAccess(catalogBatchProcessorFunction);
         stocksTable.GrantFullAccess(getProductsFunction);
         stocksTable.GrantFullAccess(getProductByIdFunction);
         stocksTable.GrantFullAccess(addProductFunction);
+        stocksTable.GrantFullAccess(catalogBatchProcessorFunction);
+        
+        CatalogItemsQueue = new Queue(scope, "CatalogBatchProcessorSQSQueue", new QueueProps
+        {
+            QueueName = "catalogItemsQueue",
+            VisibilityTimeout = Duration.Seconds(90),
+        });
+
+        catalogBatchProcessorFunction.AddEventSource(new SqsEventSource(CatalogItemsQueue, new SqsEventSourceProps
+        {
+            BatchSize = 5,
+        }));
+
+        snsTopic.GrantPublish(catalogBatchProcessorFunction);
 
         var httpApi = new HttpApi(scope, "ProductServiceAPIGateway", new HttpApiProps
         {

--- a/import-service/ImportService/ImportFileParser.cs
+++ b/import-service/ImportService/ImportFileParser.cs
@@ -1,14 +1,15 @@
 using System.Text.Json;
 using Amazon.Lambda.Core;
 using Amazon.Lambda.S3Events;
+using Amazon.SQS;
 using Common;
 using ImportService.Services;
 
 namespace ImportService;
 
-public class ImportFileParser(IImportsService importsService)
+public class ImportFileParser(IImportsService importsService, IAmazonSQS sqsClient, IEnvProvider envProvider)
 {
-    public ImportFileParser() : this(ServiceLocator.ImportsService)
+    public ImportFileParser() : this(ServiceLocator.ImportsService, ServiceLocator.SqsClient, ServiceLocator.EnvProvider)
     {
     }
 
@@ -22,14 +23,16 @@ public class ImportFileParser(IImportsService importsService)
 
             try
             {
-                var products = await importsService.ParseUploadedFile(bucket, key);
+                var products = (await importsService.ParseUploadedFile(bucket, key))
+                    .Select(x => JsonSerializer.Serialize(x, Helpers.JsonSerializerOptions))
+                    .ToList();
 
-                foreach (var product in products)
+                foreach (var productString in products)
                 {
-                    var productString = JsonSerializer.Serialize(product, Helpers.JsonSerializerOptions);
-                    context.Logger.LogInformation(
-                        $"Found in File: {s3EventRecord.S3.Object.Key} Product: {productString}");
+                    await sqsClient.SendMessageAsync(envProvider.CatalogItemsQueue(), productString);
                 }
+                
+                context.Logger.LogInformation($"Found {products.Count} in File: {s3EventRecord.S3.Object.Key}");
             }
             catch (Exception e)
             {

--- a/import-service/ImportService/ImportService.csproj
+++ b/import-service/ImportService/ImportService.csproj
@@ -16,6 +16,7 @@
         <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
         <PackageReference Include="AWSSDK.S3" Version="3.7.309.7" />
+        <PackageReference Include="AWSSDK.SQS" Version="3.7.301.25" />
         <PackageReference Include="CsvHelper" Version="33.0.1" />
     </ItemGroup>
     <ItemGroup>

--- a/import-service/ImportService/ServiceLocator.cs
+++ b/import-service/ImportService/ServiceLocator.cs
@@ -1,5 +1,6 @@
 using Amazon.Lambda.Core;
 using Amazon.S3;
+using Amazon.SQS;
 using ImportService.Services;
 
 [assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
@@ -9,6 +10,8 @@ namespace ImportService;
 public static class ServiceLocator
 {
     public static IEnvProvider EnvProvider { get; } = new EnvProvider();
+
+    public static IAmazonSQS SqsClient { get; } = new AmazonSQSClient();
 
     public static IImportsService ImportsService { get; } = new ImportsService(new AmazonS3Client(), EnvProvider);
 }

--- a/import-service/ImportService/Services/EnvProvider.cs
+++ b/import-service/ImportService/Services/EnvProvider.cs
@@ -3,6 +3,7 @@ namespace ImportService.Services;
 public interface IEnvProvider
 {
     string Bucket();
+    string CatalogItemsQueue();
 }
 
 public class EnvProvider : IEnvProvider
@@ -10,5 +11,10 @@ public class EnvProvider : IEnvProvider
     public string Bucket()
     {
         return Environment.GetEnvironmentVariable("IMPORT_BUCKET") ?? throw new ArgumentNullException($"IMPORT_BUCKET");
+    }
+
+    public string CatalogItemsQueue()
+    {
+        return Environment.GetEnvironmentVariable("CATALOG_ITEMS_QUEUE") ?? throw new ArgumentNullException($"CATALOG_ITEMS_QUEUE");
     }
 }

--- a/product-service/ProductService.Tests/CatalogBatchProcessorTest.cs
+++ b/product-service/ProductService.Tests/CatalogBatchProcessorTest.cs
@@ -1,0 +1,129 @@
+using Amazon.Lambda.SQSEvents;
+using Amazon.Lambda.TestUtilities;
+using Amazon.SimpleNotificationService;
+using Common.Models;
+using FakeItEasy;
+using ProductService.Services;
+using Xunit;
+
+namespace ProductService.Tests;
+
+public class CatalogBatchProcessorTest
+{
+    [Fact]
+    public async Task CatalogBatchProcessor_GivenCorrectMessage_ShouldAddProduct()
+    {        
+        var productsService = A.Fake<IProductsService>();
+        A.CallTo(() => productsService.IsProductValid(A<AddProductDto>._)).Returns(true);
+        var snsClient = A.Fake<IAmazonSimpleNotificationService>();
+        var envProvider = A.Fake<IEnvProvider>();
+        A.CallTo(() => envProvider.CatalogItemCreatedTopic()).Returns("topic");
+        var context = new TestLambdaContext();
+        var request = new SQSEvent
+        {
+            Records = new List<SQSEvent.SQSMessage>
+            {
+                new()
+                {
+                    Body = """
+                           {"title": "title", "description": "description", "price": 10, "count": 1}
+                           """,
+                },
+            },
+        };
+        
+        var service = new CatalogBatchProcessor(productsService, snsClient, envProvider);
+        await service.Function(request, context);
+
+        A.CallTo(() => productsService.AddProduct(A<AddProductDto>.That.Matches(
+                x => x.Title == "title" && x.Description == "description" && x.Price == 10 && x.Count == 1)))
+            .MustHaveHappened();
+    }
+    
+    [Fact]
+    public async Task CatalogBatchProcessor_GivenCorrectMessage_ShouldSendNotification()
+    {        
+        var productsService = A.Fake<IProductsService>();
+        A.CallTo(() => productsService.IsProductValid(A<AddProductDto>._)).Returns(true);
+        var snsClient = A.Fake<IAmazonSimpleNotificationService>();
+        var envProvider = A.Fake<IEnvProvider>();
+        A.CallTo(() => envProvider.CatalogItemCreatedTopic()).Returns("topic");
+        var context = new TestLambdaContext();
+        var request = new SQSEvent
+        {
+            Records = new List<SQSEvent.SQSMessage>
+            {
+                new()
+                {
+                    Body = """
+                           {"title": "title", "description": "description", "price": 10, "count": 1}
+                           """,
+                },
+            },
+        };
+        
+        var service = new CatalogBatchProcessor(productsService, snsClient, envProvider);
+        await service.Function(request, context);
+
+        A.CallTo(() => snsClient.PublishAsync("topic", A<string>._, A<CancellationToken>._))
+            .MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task CatalogBatchProcessor_GivenInvalidProduct_ShouldNotSendNotificationAndAddProduct()
+    {
+        var productsService = A.Fake<IProductsService>();
+        A.CallTo(() => productsService.IsProductValid(A<AddProductDto>._)).Returns(false);
+        var snsClient = A.Fake<IAmazonSimpleNotificationService>();
+        var envProvider = A.Fake<IEnvProvider>();
+        A.CallTo(() => envProvider.CatalogItemCreatedTopic()).Returns("topic");
+        var context = new TestLambdaContext();
+        var request = new SQSEvent
+        {
+            Records = new List<SQSEvent.SQSMessage>
+            {
+                new()
+                {
+                    Body = """
+                           {"title": "title", "description": "description", "price": 10, "count": 1}
+                           """,
+                },
+            },
+        };
+        
+        var service = new CatalogBatchProcessor(productsService, snsClient, envProvider);
+        await service.Function(request, context);
+
+        A.CallTo(() => snsClient.PublishAsync(A<string>._, A<string>._, A<CancellationToken>._)).MustNotHaveHappened();
+        A.CallTo(() => productsService.AddProduct(A<AddProductDto>._)).MustNotHaveHappened();
+    }
+    
+    [Fact]
+    public async Task CatalogBatchProcessor_GivenInvalidMessage_ShouldNotSendNotificationAndAddProduct()
+    {
+        var productsService = A.Fake<IProductsService>();
+        A.CallTo(() => productsService.IsProductValid(A<AddProductDto>._)).Returns(true);
+        var snsClient = A.Fake<IAmazonSimpleNotificationService>();
+        var envProvider = A.Fake<IEnvProvider>();
+        A.CallTo(() => envProvider.CatalogItemCreatedTopic()).Returns("topic");
+        var context = new TestLambdaContext();
+        var request = new SQSEvent
+        {
+            Records = new List<SQSEvent.SQSMessage>
+            {
+                new()
+                {
+                    Body = """
+                           {"notTitle": "title", "description": "description", "price": 10, "count": 1}
+                           """,
+                },
+            },
+        };
+        
+        var service = new CatalogBatchProcessor(productsService, snsClient, envProvider);
+        await service.Function(request, context);
+
+        A.CallTo(() => snsClient.PublishAsync(A<string>._, A<string>._, A<CancellationToken>._)).MustNotHaveHappened();
+        A.CallTo(() => productsService.AddProduct(A<AddProductDto>._)).MustNotHaveHappened();
+    }
+}

--- a/product-service/ProductService/CatalogBatchProcessor.cs
+++ b/product-service/ProductService/CatalogBatchProcessor.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.SQSEvents;
+using Amazon.SimpleNotificationService;
+using Common;
+using Common.Models;
+using ProductService.Services;
+
+namespace ProductService;
+
+public class CatalogBatchProcessor(IProductsService productsService, IAmazonSimpleNotificationService snsClient, IEnvProvider envProvider)
+{
+    public CatalogBatchProcessor() : this(ServiceLocator.ProductsService, ServiceLocator.SnsClient, ServiceLocator.EnvProvider)
+    {
+    }
+
+    public async Task Function(SQSEvent sqsEvent, ILambdaContext context)
+    {
+        context.Logger.LogInformation($"Processing {sqsEvent.Records.Count} records");
+        
+        foreach (var message in sqsEvent.Records)
+        {
+            AddProductDto? addProduct;
+            try
+            {
+                addProduct = JsonSerializer.Deserialize<AddProductDto>(message.Body, Helpers.JsonSerializerOptions);
+            }
+            catch (JsonException)
+            {
+                context.Logger.LogError($"Invalid message body: {message.Body}");
+                continue;
+            }
+
+            if (!productsService.IsProductValid(addProduct))
+            {
+                context.Logger.LogError($"Invalid message body: {message.Body}");
+                continue;
+            }
+
+            var product = await productsService.AddProduct(addProduct);
+            var productString = JsonSerializer.Serialize(product, Helpers.JsonSerializerOptions);
+            
+            context.Logger.LogInformation($"Saved product: {productString}");
+
+            await snsClient.PublishAsync(envProvider.CatalogItemCreatedTopic(), productString);
+        }
+    }
+}

--- a/product-service/ProductService/ProductService.csproj
+++ b/product-service/ProductService/ProductService.csproj
@@ -14,7 +14,9 @@
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
+    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.303.23" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.301.60" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\common\Common\Common.csproj" />

--- a/product-service/ProductService/ServiceLocator.cs
+++ b/product-service/ProductService/ServiceLocator.cs
@@ -1,4 +1,5 @@
 using Amazon.Lambda.Core;
+using Amazon.SimpleNotificationService;
 using ProductService.Services;
 
 [assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
@@ -8,6 +9,8 @@ namespace ProductService;
 public static class ServiceLocator
 {
     public static IEnvProvider EnvProvider { get; } = new EnvProvider();
+
+    public static IAmazonSimpleNotificationService SnsClient { get; } = new AmazonSimpleNotificationServiceClient();
     
     public static IProductsService ProductsService { get; } = new ProductsService(EnvProvider, new Mapper());
 }

--- a/product-service/ProductService/Services/EnvProvider.cs
+++ b/product-service/ProductService/Services/EnvProvider.cs
@@ -1,0 +1,26 @@
+namespace ProductService.Services;
+
+public interface IEnvProvider
+{
+    string ProductsTable();
+    string StocksTable();
+    string CatalogItemCreatedTopic();
+}
+
+public class EnvProvider : IEnvProvider
+{
+    public string ProductsTable()
+    {
+        return Environment.GetEnvironmentVariable("TABLE_PRODUCTS") ?? throw new ArgumentNullException($"TABLE_PRODUCTS");
+    }
+
+    public string StocksTable()
+    {
+        return Environment.GetEnvironmentVariable("TABLE_STOCKS") ?? throw new ArgumentNullException($"TABLE_STOCKS");
+    }
+
+    public string CatalogItemCreatedTopic()
+    {
+        return Environment.GetEnvironmentVariable("CATALOG_ITEM_CREATED_TOPIC") ?? throw new ArgumentNullException($"CATALOG_ITEM_CREATED_TOPIC");
+    }
+}

--- a/product-service/ProductService/aws-lambda-tools-CatalogBatchProcessor.json
+++ b/product-service/ProductService/aws-lambda-tools-CatalogBatchProcessor.json
@@ -1,0 +1,3 @@
+{
+  "function-handler": "ProductService::ProductService.CatalogBatchProcessor::Function"
+}

--- a/products.csv
+++ b/products.csv
@@ -4,3 +4,4 @@ Id,Title,Description,Price,Count
 318454b6-0d24-4e36-889b-f0df1c4e7fa6,product 3,description 3,300,30
 f9e9b1b7-b34f-4eb5-98df-5380168c3a31,product 4,description 4,400,40
 60057269-4871-4375-8653-f076d1d2c9d9,product 5,description 5,500,50
+60057269-4871-4375-8653-f076d1d2c9d0,super expensive product,super expensive description,100500,100


### PR DESCRIPTION
[Application](https://d2m0zjd9gr3n46.cloudfront.net/)
[CSV file example](https://github.com/gerrkoff/rs-aws-cloud-developer/blob/task-6c/products.csv)

# Tasks (+70)
- [x] AWS CDK Stack contains configuration for `catalogBatchProcess` function
[`catalogBatchProcessorFunction` in AWS CDK Stack](https://github.com/gerrkoff/rs-aws-cloud-developer/blob/task-6c/deployment/Deployment/ProductServiceStack.cs#L88)

- [x] AWS CDK Stack contains policies to allow lambda `catalogBatchProcess` function to interact with SNS and SQS
[`catalogBatchProcessorFunction.AddEventSource`](https://github.com/gerrkoff/rs-aws-cloud-developer/blob/task-6c/deployment/Deployment/ProductServiceStack.cs#L113)
[`snsTopic.GrantPublish`](https://github.com/gerrkoff/rs-aws-cloud-developer/blob/task-6c/deployment/Deployment/ProductServiceStack.cs#L118)

- [x] AWS CDK Stack contains configuration for SQS `catalogItemsQueue`
[`CatalogItemsQueue`](https://github.com/gerrkoff/rs-aws-cloud-developer/blob/task-6c/deployment/Deployment/ProductServiceStack.cs#L107)

- [x] AWS CDK Stack contains configuration for SNS Topic `createProductTopic` and email subscription
[`snsTopic`](https://github.com/gerrkoff/rs-aws-cloud-developer/blob/task-6c/deployment/Deployment/ProductServiceStack.cs#L25)
[Email subscription](https://github.com/gerrkoff/rs-aws-cloud-developer/blob/task-6c/deployment/Deployment/ProductServiceStack.cs#L29)

# Additional Scope (+30)
- [x] `catalogBatchProcess` lambda is covered by unit tests
[CatalogBatchProcessorTest.cs](https://github.com/gerrkoff/rs-aws-cloud-developer/blob/task-6c/product-service/ProductService.Tests/CatalogBatchProcessorTest.cs#L11)

- [x] set a Filter Policy for SNS `createProductTopic` in AWS CDK Stack and create an additional email subscription to distribute messages to different emails depending on the filter for any product attribute
[Additional subscription with Filter Policy](https://github.com/gerrkoff/rs-aws-cloud-developer/blob/task-6c/deployment/Deployment/ProductServiceStack.cs#L30)

Notification about `Super expensive product` was delivered to both `me` and `ragnareck` recipients.
![image](https://github.com/gerrkoff/rs-aws-cloud-developer/assets/14858441/94e66e73-0fc4-4b31-8618-0bf0a01a590f)